### PR TITLE
Fix knockback

### DIFF
--- a/Assets/External Assets/CollectionGame_Assets/Scripts/PickupBehavior.cs
+++ b/Assets/External Assets/CollectionGame_Assets/Scripts/PickupBehavior.cs
@@ -25,11 +25,4 @@ public class PickupBehavior : MonoBehaviour
         Destroy(gameObject);
     }
 
-    private void OnDestroy()
-    {
-        if (!LevelManager.isGameOver)
-        {
-            
-        }
-    }
 }

--- a/Assets/Prefabs/FishEnemy.prefab
+++ b/Assets/Prefabs/FishEnemy.prefab
@@ -103,7 +103,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d76ccb379309c0a41bb8cb16e2fa9f28, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerHitSFX: {fileID: 8300000, guid: a066abe16feee4b42844049cb7487ef1, type: 3}
+  playerHitSFX: {fileID: 8300000, guid: 39b65091f508052439d976ea7d1509ab, type: 3}
   player: {fileID: 0}
   moveSpeed: 5
   damageAmount: 1
@@ -318,22 +318,6 @@ PrefabInstance:
       value: 0.22
       objectReference: {fileID: 0}
     - target: {fileID: 8476378563216630830, guid: 569adc4572d7b544589fc01028ed5334, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8476378563216630830, guid: 569adc4572d7b544589fc01028ed5334, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8476378563216630830, guid: 569adc4572d7b544589fc01028ed5334, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8476378563216630830, guid: 569adc4572d7b544589fc01028ed5334, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8476378563216630830, guid: 569adc4572d7b544589fc01028ed5334, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -352,6 +336,14 @@ PrefabInstance:
     - target: {fileID: 8476378563216630830, guid: 569adc4572d7b544589fc01028ed5334, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8521377546222226322, guid: 569adc4572d7b544589fc01028ed5334, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.7763568e-14
+      objectReference: {fileID: 0}
+    - target: {fileID: 8521377546222226322, guid: 569adc4572d7b544589fc01028ed5334, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.00000007450581
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/BulletBehaviour.cs
+++ b/Assets/Scripts/BulletBehaviour.cs
@@ -4,7 +4,10 @@ using UnityEngine;
 
 public class BulletBehaviour : MonoBehaviour
 {
+    //how long the bullet lasts without 
     public float timeToLive = 3f;
+
+    //initial height of the bullet, used for height correction of both the bullet and enemies
     public float initialY;
 
     public float damage = 1;
@@ -17,6 +20,7 @@ public class BulletBehaviour : MonoBehaviour
 
     void Update()
     {
+        //bullet moves forward, and has its height and rotation continually corrected
         transform.position = new Vector3(transform.position.x, initialY, transform.position.z);
 
         Vector3 rotation = transform.rotation.eulerAngles;
@@ -26,6 +30,7 @@ public class BulletBehaviour : MonoBehaviour
         transform.rotation = Quaternion.Euler(rotation);
     }
 
+    //using a Coroutine to destroy the bullet
     IEnumerator DestroyBullet()
     {
         yield return new WaitForSeconds(timeToLive);
@@ -34,6 +39,7 @@ public class BulletBehaviour : MonoBehaviour
 
     void OnCollisionEnter(Collision collision)
     {
+        //bullet destroys itself if it hits an enemy, deactivates otherwise
         if (collision.gameObject.tag == "Enemy")
         {
             Destroy(gameObject);
@@ -46,7 +52,4 @@ public class BulletBehaviour : MonoBehaviour
         
     }
 
-    void OnTriggerEnter(Collider other)
-    {
-    }
 }

--- a/Assets/Scripts/CoinBehavior.cs
+++ b/Assets/Scripts/CoinBehavior.cs
@@ -4,33 +4,20 @@ using UnityEngine;
 
 public class CoinBehavior : MonoBehaviour
 {
-    public LevelManager levelManager;
+    //allows for double-value coins
     public float scoreValue = 1f;
     public AudioClip pickupSFX;
-    public static int pickupCount = 0;
-
     Collider collider;
-
-
+    
     // Start is called before the first frame update
     void Start()
     {
-        pickupCount++;
         collider = GetComponent<SphereCollider>();
-        levelManager = GameObject.FindGameObjectWithTag("LevelManager").GetComponent<LevelManager>();
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        if (LevelManager.isGameOver) 
-        {
-            pickupCount = 0;
-        }
     }
 
     void OnTriggerEnter(Collider other)
     {
+        //if player triggers coin, destroy coin and add to player money
         if (other.CompareTag("Player")) 
         {
             collider.enabled = false;

--- a/Assets/Scripts/DialoguePrompt.cs
+++ b/Assets/Scripts/DialoguePrompt.cs
@@ -3,16 +3,28 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
+//
 public class DialoguePrompt : MonoBehaviour
 {
+    //how does the prompt show up in the overworld?
     public Text promptTextLabel;
+    
+    //actual text
     public Text dialoguePopUp;
+
+    //what key continues the dialogue?
     public KeyCode promptKey;
+
+    //
     public string promptText;
+
+    //triggers a level flag upon dialogue completion if true
     public bool requiredToProgress = false;
 
+    //opens shop prompt if true
     public bool isMerchant = false;
 
+    //refers to the "next" dialogue object in the level, makes it interactable if so 
     public GameObject nextDialogueObject;
 
     public enum InteractableEnityType
@@ -23,7 +35,10 @@ public class DialoguePrompt : MonoBehaviour
 
     public InteractableEnityType interactableType = InteractableEnityType.NPC;
 
+    //separate script object that contains the lines to be "said" (attached to same GameObject)
     DialogueScript dialogueScript;
+
+    //NPC/Object behavior script (attached to same GameObject)
     EntityBehaviour entityBehaviour;
     bool isDialogueRunning = false;
     bool canActivateDialogue = false;
@@ -102,6 +117,7 @@ public class DialoguePrompt : MonoBehaviour
             ExitDialogue();
             if (requiredToProgress)
             {
+                //send LevelManager an update to the objective
                 LevelManager.currObjective.ObjectiveUpdate(ObjectiveType.INTERACTION, 1);
                 //no longer allow this dialogue to progress the story
                 requiredToProgress = false;

--- a/Assets/Scripts/DialogueScript.cs
+++ b/Assets/Scripts/DialogueScript.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class DialogueScript : MonoBehaviour
 {
+    //put dialogue here through the inspector
     public string[] dialogue;
     public bool isComplete = false;
     private int index = 0;

--- a/Assets/Scripts/EnemyHealth.cs
+++ b/Assets/Scripts/EnemyHealth.cs
@@ -44,10 +44,6 @@ public class EnemyHealth : MonoBehaviour
         isGettingHit = false;
     }
 
-    void Update()
-    {
-        
-    }
 
     private void OnTriggerEnter(Collider other)
     {

--- a/Assets/Scripts/FishEnemyBehavior.cs
+++ b/Assets/Scripts/FishEnemyBehavior.cs
@@ -21,6 +21,10 @@ public class FishEnemyBehavior : MonoBehaviour
 
     NavMeshAgent agent;
 
+    //set cooldown for attacking player to prevent double-taps and corner combos; 
+    //trigger collider is used to hurt player and thus will be deactivated for a short time afterward
+    Collider triggerCollider; public float collisionCooldown = 0.5f; float collisionTimer = 0;
+
     void Start()
     {
         if (player == null)
@@ -30,6 +34,7 @@ public class FishEnemyBehavior : MonoBehaviour
         isAggro = false;
 
         enemyHealth = GetComponent<EnemyHealth>();
+        triggerCollider = GetComponents<Collider>()[1];
 
         agent = GetComponent<NavMeshAgent>();
         agent.stoppingDistance = 0;
@@ -55,6 +60,14 @@ public class FishEnemyBehavior : MonoBehaviour
             }
             if (enemyHealth.isGettingHit) {
                 fishLookAt();
+            }
+            //if 
+            if (collisionTimer <= 0 & !enemyHealth.isDead)
+            {
+                triggerCollider.enabled = true;
+            }
+            else {
+                collisionTimer -= Time.deltaTime;
             }
         }
         else {
@@ -96,12 +109,15 @@ public class FishEnemyBehavior : MonoBehaviour
         var playerHealth = other.GetComponent<PlayerHealth>();
         playerHealth.TakeDamage(damageAmount);
 
+        //knockback wrapper is handled in PlayerHealth, which calls a function in PlayerController
         Vector3 moveDirection = (other.gameObject.transform.position - transform.position).normalized;
         playerHealth.TriggerKnockback(moveDirection);
 
         AudioSource.PlayClipAtPoint(playerHitSFX, Camera.main.transform.position);
 
-        
+        //deactivate player harming capabilities
+        triggerCollider.enabled = false;
+        collisionTimer = collisionCooldown;        
     }
 
     private void fishLookAt()

--- a/Assets/Scripts/FishEnemyBehavior.cs
+++ b/Assets/Scripts/FishEnemyBehavior.cs
@@ -95,18 +95,13 @@ public class FishEnemyBehavior : MonoBehaviour
     {
         var playerHealth = other.GetComponent<PlayerHealth>();
         playerHealth.TakeDamage(damageAmount);
-        var playerController = other.GetComponent<PlayerController>();
-        
+
         Vector3 moveDirection = (other.gameObject.transform.position - transform.position).normalized;
+        playerHealth.TriggerKnockback(moveDirection);
 
         AudioSource.PlayClipAtPoint(playerHitSFX, Camera.main.transform.position);
 
-        float knockbackTimer = 0.75f;
-        while (knockbackTimer >= 0)
-        {
-            playerController.controller.Move(moveDirection * Time.deltaTime * 5);
-            knockbackTimer -= Time.deltaTime;
-        }
+        
     }
 
     private void fishLookAt()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -35,6 +35,7 @@ public class PlayerController : MonoBehaviour
     Plane groundPlane;
     ThrowableBehaviour tb;
     GameObject gunPoint;
+
     public CharacterController controller;
     PlayerAnimation animHandler;
 
@@ -86,7 +87,6 @@ public class PlayerController : MonoBehaviour
                 StartDash();
             }
 
-            Debug.Log(knockbackDirection);
 
         }
 
@@ -376,6 +376,7 @@ public class PlayerController : MonoBehaviour
             Debug.Log("Starting knockback in playercontroller");
             knockbackTimer = knockbackTime;
             knockbackDirection = moveDirection;
+
             
         }
     }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -20,6 +20,9 @@ public class PlayerController : MonoBehaviour
     float bulletRefresh, pulseRefresh;
 
     float dashTimeLeft = 0, dashRefresh = 0;
+    
+    Vector3 knockbackDirection; public float knockbackTimer = 0.75f;
+
 
     UIController ui;
 
@@ -83,6 +86,8 @@ public class PlayerController : MonoBehaviour
                 StartDash();
             }
 
+            Debug.Log(knockbackDirection);
+
         }
 
         SetSliders();
@@ -97,7 +102,7 @@ public class PlayerController : MonoBehaviour
                 Vector3 moveDirection = input;
 
                 //set speed
-                if (Input.GetKey(KeyCode.LeftShift))
+                if (Input.GetKey(KeyCode.LeftShift) & knockbackTimer <= 0)
                 {
                     playerSpeed = 10f;
                     animHandler.isRunning = true;
@@ -106,6 +111,14 @@ public class PlayerController : MonoBehaviour
                 {
                     playerSpeed = 5f;
                     animHandler.isRunning = false;
+                }
+
+                if (knockbackTimer > 0)
+                {
+                    //hijack player movement to get knocked back
+                    moveDirection = knockbackDirection * (knockbackTimer * 10f);
+                    knockbackTimer -= Time.deltaTime;
+                    knockbackTimer = Mathf.Clamp(knockbackTimer,0, 100);
                 }
 
                 moveDirection *= playerSpeed;
@@ -135,7 +148,6 @@ public class PlayerController : MonoBehaviour
                 animHandler.SetMoveDirection(input.normalized);
 
             }
-            //Debug.Log("Dash time left: " + dashTimeLeft + "; dash refresh: " + dashRefresh);
 
         }
 
@@ -357,5 +369,13 @@ public class PlayerController : MonoBehaviour
             ui.SetSlider(UISlider.HOMING, (bulletCooldown - bulletRefresh)/bulletCooldown);
             ui.SetSlider(UISlider.GRENADE, (bulletCooldown - bulletRefresh)/bulletCooldown);
             ui.SetSlider(UISlider.PULSE, (pulseCooldown - pulseRefresh)/pulseCooldown);
+        }
+
+        public void Knockback(Vector3 moveDirection, float knockbackTime = 0.5f)
+        {
+            Debug.Log("Starting knockback in playercontroller");
+            knockbackTimer = knockbackTime;
+            knockbackDirection = moveDirection;
+            
         }
     }

--- a/Assets/Scripts/PlayerHealth.cs
+++ b/Assets/Scripts/PlayerHealth.cs
@@ -6,6 +6,8 @@ using UnityEngine.UI;
 public class PlayerHealth : MonoBehaviour
 {
     public int startingHealth = 10;
+
+    PlayerController controller;
     //public AudioClip deadSFX;
     public Slider healthSlider;
     public LevelManager levelManager;
@@ -17,6 +19,7 @@ public class PlayerHealth : MonoBehaviour
     {
         currentHealth = startingHealth;
         healthSlider.value = currentHealth;
+        controller = GetComponent<PlayerController>();
     }
 
     // Update is called once per frame
@@ -37,6 +40,11 @@ public class PlayerHealth : MonoBehaviour
         {
             PlayerDies();
         }
+    }
+
+    public void TriggerKnockback(Vector3 moveDirection)
+    {
+        controller.Knockback(moveDirection);
     }
 
     public void TakeHealth(int healthAmount)


### PR DESCRIPTION
We got feedback that the knockback after the player gets hit feels buggy and unresponsive. This PR fixes this by integrating knockback into player movement, along with other fixes to enemy-player interactions.
- Player knockback now disables other movement for a short time.
- Enemies can no longer double-hit players.
- Added general documentation to involved scripts and some others.