### PR TITLE
General save/load bugfixes

### DIFF
--- a/Assets/Scripts/CoinBehavior.cs
+++ b/Assets/Scripts/CoinBehavior.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class CoinBehavior : MonoBehaviour
 {
     //allows for double-value coins
-    public float scoreValue = 1f;
+    public int scoreValue = 1;
     public AudioClip pickupSFX;
     Collider collider;
     

--- a/Assets/Scripts/DialoguePrompt.cs
+++ b/Assets/Scripts/DialoguePrompt.cs
@@ -151,7 +151,8 @@ public class DialoguePrompt : MonoBehaviour
 
     void EnableUI(bool isEnabled)
     {
-        if (playerStatePanel)
+        GameObject playerStatePanel = GameObject.Find("PlayerStatePanel");
+        if (playerStatePanel != null)
         {
             playerStatePanel.SetActive(isEnabled);
         }

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -186,11 +186,13 @@ public class LevelManager : MonoBehaviour
 
     void LoadCurrentLevel()
     {
+        //when current level is reloaded (i.e. player lost), retrieve saved money count (or default $0)
         money = PlayerPrefs.GetInt("Money", 0);
         SceneManager.LoadScene(SceneManager.GetActiveScene().name);
     }
 
     void LoadNextLevel() {
+        //when level is beaten, save player's money count
         PlayerPrefs.SetInt("Money", money);
         SceneManager.LoadScene(nextLevel);
     }

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -27,7 +27,7 @@ public class LevelManager : MonoBehaviour
 
     public string nextLevel;
 
-    public static float money = 3;
+    public static int money = 3;
 
     public Image fadeImage;
 
@@ -85,6 +85,7 @@ public class LevelManager : MonoBehaviour
     private void initObjectiveList()
     {
         Debug.Log("Calling initObjList!");
+        objectiveList = new List<Objective>();
         
         foreach (ObjectiveParam op in objectiveParams)
         {
@@ -185,10 +186,12 @@ public class LevelManager : MonoBehaviour
 
     void LoadCurrentLevel()
     {
+        money = PlayerPrefs.GetInt("Money", 0);
         SceneManager.LoadScene(SceneManager.GetActiveScene().name);
     }
 
     void LoadNextLevel() {
+        PlayerPrefs.SetInt("Money", money);
         SceneManager.LoadScene(nextLevel);
     }
 

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -28,6 +28,7 @@ public class MainMenu : MonoBehaviour
     public void StartGame()
     {
         screenManager.FadeOut(fadeImage, fadeTime);
+        PlayerPrefs.SetInt("Money", 3);
         // FadeOut();
         Invoke("NextScene", fadeTime + .2f);
     }

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -28,6 +28,7 @@ public class MainMenu : MonoBehaviour
     public void StartGame()
     {
         screenManager.FadeOut(fadeImage, fadeTime);
+        //every time game starts, create save data with initial money count
         PlayerPrefs.SetInt("Money", 3);
         // FadeOut();
         Invoke("NextScene", fadeTime + .2f);


### PR DESCRIPTION
- Add saving/loading amounts of money to PlayerPrefs so players can't continuously grind money by dying on the same level.
- Fixed a bug where dying on Level 1 prevented objectives from loading correctly.
- Fixed a bug where the player UI was not recognized by the LevelManager script.